### PR TITLE
Update references.py

### DIFF
--- a/open_problems/models/references.py
+++ b/open_problems/models/references.py
@@ -41,7 +41,10 @@ class Reference(models.Model):
     doi = models.CharField(max_length=50)
     relevance = models.PositiveSmallIntegerField()
     publish_date = models.DateField()
-    isbn = models.TextField()
+    # edited by Hamid
+    #isbn = models.TextField()
+    isbn = models.CharField(max_length=13)
+    # end of edit by Hamid
     journal_id = models.ForeignKey(Journal, on_delete=models.SET_NULL, null=True)
     authors = models.ManyToManyField(Author)
 


### PR DESCRIPTION
I noticed that I had made a mistake in defining data type of the field ISBN in References. ISBN is just a 13-digit code of the books and doesn’t need a text data type.